### PR TITLE
release: v2.4.0

### DIFF
--- a/cmd/ksm-mcp/main.go
+++ b/cmd/ksm-mcp/main.go
@@ -8,7 +8,7 @@ import (
 
 // Version is the current version of ksm-mcp
 // This must match the git tag when creating releases
-const Version = "v2.3.0"
+const Version = "v2.4.0"
 
 func main() {
 	// Set version for commands


### PR DESCRIPTION
## Summary
Bump `Version` constant from `v2.3.0` to `v2.4.0` so the release pipeline can publish a new tag.

## Context
Captures the changes already merged on main since v2.3.0:
- Multi-arch Docker publish to `keeper/keeper-mcp-server` (#6, #7)
- Bump `golang.org/x/crypto` to v0.45.0 (Dependabot alerts #4, #5)
- Bump build/CI Go toolchain to 1.24
- gosec false-positive annotations

## How to release after merge
1. Tag main:
   ```
   git tag v2.4.0 && git push origin v2.4.0
   ```
2. Tag push triggers `release.yml`, which runs tests, builds binaries for all platforms, creates the GitHub release, and pushes multi-arch (`linux/amd64,linux/arm64`) Docker images to `keeper/keeper-mcp-server:{v2.4.0,2.4,latest}`.

## Pre-flight
The Docker Hub token in the `poc` GitHub environment must have push perms on the `keeper/` namespace; previously this workflow pushed to `keepersecurityinc/`. If the token is namespace-scoped, swap it before tagging.