### PR TITLE
ci: also publish v-prefixed Docker tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,6 +290,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}},value=${{ needs.release.outputs.version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.version }}
+            type=raw,value=${{ needs.release.outputs.version }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Summary
Add `type=raw,value=<git tag>` to the `docker/metadata-action` config so each release also publishes a `v`-prefixed Docker tag (e.g. `:v2.5.0`) alongside the existing `:2.5.0`, `:2.5`, and `:latest`.

## Context
The `docker/metadata-action`'s `type=semver,pattern={{version}}` strips the leading `v`, which is why v2.4.0 published only `:2.4.0` / `:2.4` / `:latest`. Earlier releases (e.g. `:v2.3.0`) used the `v`-prefixed form, so the omission breaks pinning continuity for any user pinned to that scheme.

This adds the v-prefixed tag without removing any existing ones — both styles will be available going forward.

Effective starting with the next release.