### PR TITLE
release: v2.4.1

### DIFF
--- a/cmd/ksm-mcp/main.go
+++ b/cmd/ksm-mcp/main.go
@@ -8,7 +8,7 @@ import (
 
 // Version is the current version of ksm-mcp
 // This must match the git tag when creating releases
-const Version = "v2.4.0"
+const Version = "v2.4.1"
 
 func main() {
 	// Set version for commands


### PR DESCRIPTION
## Summary
Bump `Version` constant from `v2.4.0` to `v2.4.1`.

## Context
Captures the fix already merged on main since v2.4.0:
- Remove stray `DEBUG:` prints from record template loader (#10) — fixes #6
- Also publish `v`-prefixed Docker tag in metadata-action (#9)